### PR TITLE
eval_mt - rewrite while{ps|grep} into single ps + don't abuse globals

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -2,8 +2,7 @@
 
 source ./functions.sh
 
-#cpu=4
-#export cpu
+#evalThreads=8
 
 for i in {1..100} ; do
 


### PR DESCRIPTION
the `ps` loop is not necessary. Also reduced the number of `export`s as it clutters the shell. When using global variables - prefix them with your functionname so you don't overwrite anything (eg. `cpu` is way too generic as a variable to clutter the global scope with).